### PR TITLE
Update Black to 22.3.0

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-pip install black==21.7b0 mypy==0.900 pylint==2.9.6 pylint-fail-under==0.3.0 reorder-python-imports==2.6.0 safety==1.10.3
+pip install black==22.3.0 mypy==0.900 pylint==2.9.6 pylint-fail-under==0.3.0 reorder-python-imports==2.6.0 safety==1.10.3
 pip install -r requirements.txt
 
 black -S -l $BLACK_LINE_MAXLEN --check .


### PR DESCRIPTION
Changes proposed in the pull request:
- Updating Black hoping it will solve the dependency issue as described in https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click

@cfedermann
